### PR TITLE
Oauth2 token expires before user session and generates an Unauthorize Request

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,6 @@ management:
   security:
     enabled: true
   context-path: /manage
+server:
+  session:
+    timeout: 240


### PR DESCRIPTION
Session timeout should be reduced to expire before Oauth2 Token, but after UI . 
See Orange-OpenSource/elpaaso-sandbox-ui#4
