### PR TITLE
Tentative fix for issue #17

### DIFF
--- a/src/main/java/com/orange/clara/cloud/services/sandbox/ElpaasoSandboxServiceApplication.java
+++ b/src/main/java/com/orange/clara/cloud/services/sandbox/ElpaasoSandboxServiceApplication.java
@@ -63,6 +63,6 @@ public class ElpaasoSandboxServiceApplication {
     public CloudFoundryClient getCloudFoundryClientAsAdmin() {
         LOGGER.debug("Creating new ADMIN CloudFoundry client ");
         CloudCredentials credentials = new CloudCredentials(cloudfoundryTarget.getCredentials().getUserId(), cloudfoundryTarget.getCredentials().getPassword());
-        return new CloudFoundryClient(credentials, cloudfoundryTarget.getApiUrl(), cloudfoundryTarget.getOrg(), cloudfoundryTarget.getSpace(), cloudfoundryTarget.isTrustSelfSignedCerts());
+        return new CloudFoundryClient(credentials, cloudfoundryTarget.getApiUrl(), cloudfoundryTarget.isTrustSelfSignedCerts());
     }
 }


### PR DESCRIPTION
Avoid loading all spaces at start up, by using CC client constructor which does not set a default space

Fix #17